### PR TITLE
[Unlayer] Update published view destination

### DIFF
--- a/packages/laravel-mailcoach-unlayer/src/MailcoachUnlayerServiceProvider.php
+++ b/packages/laravel-mailcoach-unlayer/src/MailcoachUnlayerServiceProvider.php
@@ -15,7 +15,7 @@ class MailcoachUnlayerServiceProvider extends ServiceProvider
 
         if ($this->app->runningInConsole()) {
             $this->publishes([
-                __DIR__ . '/../resources/views' => base_path('resources/views/vendor/mailcoach/unlayer'),
+                __DIR__ . '/../resources/views' => base_path('resources/views/vendor/mailcoach-unlayer'),
             ], 'mailcoach-unlayer-views');
         }
 


### PR DESCRIPTION
Hi there,

I'm using Mailcoach self-hosted with my company and I would want to fix a very little problem.

If I need to publish unlayer view to update some things (like using my own controller to upload files), changes on this view are not considered because the destination folder is wrong. If I put published view in `resources/views/vendor/maicoach-unlayer/` instead of `resources/views/vendor/maicoach/unlayer/` changes take effect.

Thanks,
Simon.